### PR TITLE
Create CONSUL_IGNOREVHM option

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changelog
 0.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Create new CONSUL_IGNOREVHM option [instification]
 
 
 0.2 (2021-09-16)

--- a/README.rst
+++ b/README.rst
@@ -51,3 +51,7 @@ consul_ignore
     Skips setting consul key values. Useful if you have multiple instances that
     share the same code. You can set this value on specific instances and no
     key/values will be set in consul.
+
+consul_ignorevhm
+    Skips individual VHM hosts from being set. This should match the first part of the vhm string (i.e. before `/VirtualHostBase`)
+    e.g. `CONSUL_IGNOREVHM="test.localhost,test2.localhost"` which will prevent either of the corresponding vhm values being set in consul.

--- a/src/collective/zopeconsul/consulserver.py
+++ b/src/collective/zopeconsul/consulserver.py
@@ -18,9 +18,10 @@ class Consul(object):
         self.server = consul.Consul(scheme=r.scheme,
                                     host=r.hostname,
                                     port=r.port)
-        self.instance = self.getconf('consul_instancename', None)
+        self.instance = self.getconf('consul_instancename')
         self.prefix = self.getconf('consul_prefix', 'zope/')
         self.ignore = self.getconf('consul_ignore', 0)
+        self.ignorevhm = self.getconf('consul_ignorevhm', "").split(',')
 
     def getconf(self, name, default=None):
         value = os.environ.get(name.upper(), None)

--- a/src/collective/zopeconsul/vhm.py
+++ b/src/collective/zopeconsul/vhm.py
@@ -90,7 +90,7 @@ def send_vhm(host_map, consul=None):
     old_values = server.kv.get(vhm, recurse=True)
     if old_values:
         server.kv.delete(vhm, recurse=True)
-    for host in host_map:
+    for host in [host for host in host_map if host not in consul.ignorevhm]:
         for nothing, values in host_map[host].items():
             server.kv.put('%s/%s' % (vhm, host), '%s' % '/'.join(values))
 


### PR DESCRIPTION
This PR allows individual sites to be excluded when setting VHM values in consul.

The primary use case for this is so that you can receive traffic to a particular host without it being the default for all traffic. Without this setting you would need to then handle VHM in the request url.