### PR TITLE
Only set values if they differ from consul values

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Changelog
 ----------------
 
 - Create new CONSUL_IGNOREVHM option [instification]
+- Only update VHM values if they differ from consul [instification]
 
 
 0.2 (2021-09-16)


### PR DESCRIPTION
This PR extends the VHM code so that it reads the existing values and only updates consul if the VHM values differ.

If the values differ the consul values will be deleted and recreated.

This PR will significantly reduce the number of writes being sent to consul